### PR TITLE
Version 1.0.7

### DIFF
--- a/Fededim.Extensions.Configuration.Protected.ConsoleTest/Program.cs
+++ b/Fededim.Extensions.Configuration.Protected.ConsoleTest/Program.cs
@@ -94,12 +94,14 @@ public class Program
 
         // retrieve the strongly typed AppSettings configuration class, we use IOptionsMonitor in order to be notified on any reloads of appSettings
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<AppSettings>>();
+        var appSettings = optionsMonitor.CurrentValue;
         optionsMonitor.OnChange(appSettingsReloaded => {
             // this breakpoint gets hit when the appsettings have changed due to a configuration reload, please check that the value of "Int" property inside appSettingsReloaded class is different from the one inside appSettings class
-            Console.WriteLine($"appsettings.{Environment.GetEnvironmentVariable("DOTNETCORE_ENVIRONMENT")}.json has been reloaded!");
+            // note that also there is an unavoidable framework bug on ChangeToken.OnChange which could get called multiple times when using FileSystemWatchers see https://github.com/dotnet/aspnetcore/issues/2542
+            // see also the remarks section of FileSystemWatcher https://learn.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher.created?view=net-8.0#remarks
+            Console.WriteLine($"OnChangeEvent: appsettings.{Environment.GetEnvironmentVariable("DOTNETCORE_ENVIRONMENT")}.json has been reloaded! appSettings Int {appSettings.Int} appSettingsReloaded {appSettingsReloaded.Int}");
             Debugger.Break();
         });
-        var appSettings = optionsMonitor.CurrentValue;
 
         // please check that all values inside appSettings class are actually decrypted with the right value, make a note of the value of "Int" property it will change on the next second breakpoint
         Debugger.Break();
@@ -111,14 +113,20 @@ public class Program
         Debug.Assert(appSettings.EncryptedXmlSecretKey == appSettings.PlainTextXmlSecretKey);
         Debug.Assert(appSettings.EncryptedInMemorySecretKey == appSettings.PlainTextInMemorySecretKey);
 
-        // configuration reload example, updates inside appsettings.<environment>.json the property "Int": <whatever>, --> "Int": "Protected:{<random number>},"
-        var environmentAppSettings = File.ReadAllText($"appsettings.{Environment.GetEnvironmentVariable("DOTNETCORE_ENVIRONMENT")}.json");
-        environmentAppSettings = new Regex("\"Int\":.+?,").Replace(environmentAppSettings, $"\"Int\": \"{dataProtector.ProtectConfigurationValue($"Protect:{{{new Random().Next(0, 100000)}}}")}\",");
-        File.WriteAllText($"appsettings.{Environment.GetEnvironmentVariable("DOTNETCORE_ENVIRONMENT")}.json", environmentAppSettings);
+        // multiple configuration reload example
+        int i = 0;
+        while (i++<5)
+        {
+            // updates inside appsettings.<environment>.json the property "Int": <whatever>, --> "Int": "Protected:{<random number>},"
+            var environmentAppSettings = File.ReadAllText($"appsettings.{Environment.GetEnvironmentVariable("DOTNETCORE_ENVIRONMENT")}.json");
+            environmentAppSettings = new Regex("\"Int\":.+?,").Replace(environmentAppSettings, $"\"Int\": \"{dataProtector.ProtectConfigurationValue($"Protect:{{{new Random().Next(0, 1000000)}}}")}\",");
+            File.WriteAllText($"appsettings.{Environment.GetEnvironmentVariable("DOTNETCORE_ENVIRONMENT")}.json", environmentAppSettings);
 
-        // wait 5 seconds for the reload to take place, please check on this breakpoint that the value of "Int" property has changed in appSettings class and it is the same of appSettingsReloaded
-        Thread.Sleep(5000);
-        appSettings = optionsMonitor.CurrentValue;
-        Debugger.Break();
+            // wait 5 seconds for the reload to take place, please check on this breakpoint that the value of "Int" property has changed in appSettings class and it is the same of appSettingsReloaded
+            Thread.Sleep(5000);
+            appSettings = optionsMonitor.CurrentValue;
+            Console.WriteLine($"ConfigurationReloadLoop: appSettings Int {appSettings.Int}");
+            Debugger.Break();
+        }
     }
 }

--- a/Fededim.Extensions.Configuration.Protected/ConfigurationBuilderExtensions.cs
+++ b/Fededim.Extensions.Configuration.Protected/ConfigurationBuilderExtensions.cs
@@ -18,6 +18,16 @@ namespace Fededim.Extensions.Configuration.Protected
     public static class ConfigurationBuilderExtensions
     {
         /// <summary>
+        /// the <see cref="FilesDecoding"/> entry for JsonDecodingFunction
+        /// </summary>
+        public static (Regex filenameRegex, Func<String, String> dataToEncryptDecodingFunction) JsonDecodingFunction = (new Regex("(.*)\\.json"), JsonDecode);
+
+        /// <summary>
+        /// the <see cref="FilesDecoding"/> entry for XmlDecodingFunction
+        /// </summary>
+        public static (Regex filenameRegex, Func<String, String> dataToEncryptDecodingFunction) XmlDecodingFunction = (new Regex("(.*)\\.xml"), XmlDecode);
+
+        /// <summary>
         /// it is a configuration list for interpreting and decoding raw input data which must be encrypted with the <see cref="ProtectFiles"/> method. It is a list of couples made up of:
         /// - a regex on the filename which if matched applies the associated dataToEncryptDecodingFunction
         /// - a dataToEncryptDecodingFunction which basically interprets the raw string data and decodes it returning a new string
@@ -26,10 +36,9 @@ namespace Fededim.Extensions.Configuration.Protected
         /// </summary>
         public static List<(Regex filenameRegex, Func<String, String> dataToEncryptDecodingFunction)> FilesDecoding { get; private set; } = new List<(Regex filenameRegex, Func<string, string> dataToEncryptDecodingFunction)>()
         {
-            (new Regex("(.*)\\.json"), JsonDecode),
-            (new Regex("(.*)\\.xml"), XmlDecode)
+         JsonDecodingFunction,
+         XmlDecodingFunction
         };
-
 
 
         /// <summary>

--- a/Fededim.Extensions.Configuration.Protected/Fededim.Extensions.Configuration.Protected.csproj
+++ b/Fededim.Extensions.Configuration.Protected/Fededim.Extensions.Configuration.Protected.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
 
     <PublishSingleFile>true</PublishSingleFile>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <Authors>Federico Di Marco &lt;fededim@gmail.com&gt;</Authors>
     <Description>Fededim.Extensions.Configuration.Protected is an improved ConfigurationBuilder which allows partial or full encryption of configuration values stored inside any possible ConfigurationSource and fully integrated in the ASP.NET Core architecture. Basically, it implements a custom ConfigurationBuilder and a custom ConfigurationProvider defining a custom tokenization tag which whenever found decrypts the enclosed encrypted data using ASP.NET Core Data Protection API.</Description>
     <Copyright>$([System.DateTime]::UtcNow.Year)</Copyright>
@@ -43,6 +43,10 @@
 
       v1.0.6
       - Bugfix: the ProtectFiles method simply read the raw files which need to be encrypted using File.ReadAllText, whereas it should also decode the file according to its format. By default two decoders are now provided for both JSON and XML files and an extension point (FilesDecoding public property) if additional formats must be supported.
+
+      v1.0.7
+      - Improvement: the ProtectedConfigurationProvider.RegisterReloadCallback now uses the framework standard static utility class ChangeToken.OnChange to register the underlying provider configuration changes
+      - Improvement: added two additional public static properties inside ConfigurationBuilderExtensions in order to allow them to be referenced if needed: JsonDecodingFunction and XmlDecodingFunction
     </PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
- Improvement: the ProtectedConfigurationProvider.RegisterReloadCallback now uses the framework standard static utility class ChangeToken.OnChange to register the underlying provider configuration changes
- Improvement: added two additional public static properties inside ConfigurationBuilderExtensions in order to allow them to be referenced if needed: JsonDecodingFunction and XmlDecodingFunction
