### PR TITLE
Updated to version 1.0.8

### DIFF
--- a/Fededim.Extensions.Configuration.Protected.ConsoleTest/AppSettings.cs
+++ b/Fededim.Extensions.Configuration.Protected.ConsoleTest/AppSettings.cs
@@ -56,6 +56,7 @@ namespace Fededim.Extensions.Configuration.Protected.ConsoleTest
         public String PlainTextXmlSecretKey {  get; set; }
         public Dictionary<String, String> TransientFaultHandlingOptions { get; set; }
         public Logging Logging { get; set; }
+        public String EmptyElement { get; set; }
 
 
         // settings defined in InMemoryCollection

--- a/Fededim.Extensions.Configuration.Protected.ConsoleTest/appsettings.development.json
+++ b/Fededim.Extensions.Configuration.Protected.ConsoleTest/appsettings.development.json
@@ -5,7 +5,7 @@
   "Nullable": {
     "DateTime": "Protect:{2016-10-01T20:34:56.789Z}",
     "Double": "Protect:{123.456}",
-    "DoubleArray": [ "2.71", "Protect:{3.14}", "6.67" ],
+    "DoubleArray": [ "2.71", "Protect:{3.14}", "6.67", "Protect:{%customSubPurpose%}:{3.14}" ],
     "Int": "Protect:{98765}",
     "Bool": "Protect:{true}"
   }

--- a/Fededim.Extensions.Configuration.Protected.ConsoleTest/appsettings.json
+++ b/Fededim.Extensions.Configuration.Protected.ConsoleTest/appsettings.json
@@ -4,7 +4,7 @@
   "Bool": false,
   "DateTime": "2016-01-01T12:34:56.789",
   "IntArray": [ 1, 2 ],
-  "PlainTextJsonSpecialCharacters": "\\!*+?|{[()^$.#\"",
+  "PlainTextJsonSpecialCharacters": "\\!*+?|{[()^$.#\u0022",
   "EncryptedJsonSpecialCharacters": "Protect:{\\!*+?|{[()^$.#\u0022}",
   "Nullable": {
     "Int": null,

--- a/Fededim.Extensions.Configuration.Protected.ConsoleTest/appsettings.xml
+++ b/Fededim.Extensions.Configuration.Protected.ConsoleTest/appsettings.xml
@@ -5,6 +5,7 @@
   <TransientFaultHandlingOptions>
     <Enabled>true</Enabled>
     <AutoRetryDelay>OtherProtect:{00:00:07}</AutoRetryDelay>
+    <AutoRetryDelaySubPurpose>OtherProtect:{sUbPuRpOsE}:{00:00:07}</AutoRetryDelaySubPurpose>
   </TransientFaultHandlingOptions>
   <Logging>
     <LogLevel>
@@ -12,4 +13,5 @@
       <Microsoft>OtherProtect:{Warning}</Microsoft>
     </LogLevel>
   </Logging>
+  <EmptyElement></EmptyElement>  
 </configuration>

--- a/Fededim.Extensions.Configuration.Protected/Fededim.Extensions.Configuration.Protected.csproj
+++ b/Fededim.Extensions.Configuration.Protected/Fededim.Extensions.Configuration.Protected.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
 
     <PublishSingleFile>true</PublishSingleFile>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <Authors>Federico Di Marco &lt;fededim@gmail.com&gt;</Authors>
     <Description>Fededim.Extensions.Configuration.Protected is an improved ConfigurationBuilder which allows partial or full encryption of configuration values stored inside any possible ConfigurationSource and fully integrated in the ASP.NET Core architecture. Basically, it implements a custom ConfigurationBuilder and a custom ConfigurationProvider defining a custom tokenization tag which whenever found decrypts the enclosed encrypted data using ASP.NET Core Data Protection API.</Description>
     <Copyright>$([System.DateTime]::UtcNow.Year)</Copyright>
@@ -47,13 +47,19 @@
       v1.0.7
       - Improvement: the ProtectedConfigurationProvider.RegisterReloadCallback now uses the framework standard static utility class ChangeToken.OnChange to register the underlying provider configuration changes
       - Improvement: added two additional public static properties inside ConfigurationBuilderExtensions in order to allow them to be referenced if needed: JsonDecodingFunction and XmlDecodingFunction
+
+      v1.0.8
+      - Improvement: introduced FileProtectProcessor and IFileProtectProcessor interface for implementing a custom file protect processor used to read, encrypt and return the encrypted file as string. Json, Xml and Raw processors are provided by default.
+      - Improvement: added custom string parameter purposeString in ProtectedConfigurationBuilder constructor in order to specify a custom purpose string for encryption/decryption, besides the integer keyNumber parameter.
+      - Improvement: added subPurpose optional part in DefaultProtectRegexString, DefaultProtectedRegexString and DefaultProtectedReplaceString in order to allow an optional per key purpose string override.
+      - Improvement: added some data to json (one element in Nullable:DoubleArray of appsettings.development.json) and xml file (AutoRetryDelaySubPurpose under TransientFaultHandlingOptions) of Fededim.Extensions.Configuration.Protected.ConsoleTest in order to exemplify the per key purpose string override.
     </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
 
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />

--- a/Fededim.Extensions.Configuration.Protected/ProtectFileProcessors.cs
+++ b/Fededim.Extensions.Configuration.Protected/ProtectFileProcessors.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Fededim.Extensions.Configuration.Protected
+{
+    /// <summary>
+    /// This is the interface which must be implemented by a custom FileProtectProcessor. It contains a single method <see cref="ProtectFile"/> used to read, encrypt and return the encrypted file as string.
+    /// </summary>
+    public interface IFileProtectProcessor
+    {
+        /// <summary>
+        /// This method actually implements a custom FileProtectProcessor which must read, encrypt and return the encrypted file as string.
+        /// </summary>
+        /// <param name="rawFileText">The is the raw input file as a string</param>
+        /// <param name="protectRegex">This is the configured protected regex which must be matched in file values in order to choose whether to encrypt or not the data.</param>
+        /// <param name="protectFunction">This is the protect function taking the plaintext data as input and producing encrypted base64 data as output</param>
+        /// <returns>the encrypted file as a string</returns>
+        String ProtectFile(String rawFileText, Regex protectRegex, Func<String, String> protectFunction);
+    }
+
+
+
+    /// <summary>
+    /// ProtectFilesOptions is a class used to specify the custom ProtectFileProcessors used by <see cref="ConfigurationBuilderExtensions.ProtectFiles"/> method. Essentially for each processor you must provide a class <see cref="FileProtectProcessor"/> which must implement 
+    /// the <see cref="IFileProtectProcessor"/> interface in order to process the raw string data of the input file according to its format conventions (<see cref="JsonFileProtectProcessor"/> and <see cref="XmlFileProtectProcessor"/>) when the filename matches 
+    /// the provided regular expression (<see cref="FilenameRegex"/>)
+    /// </summary>
+    public class FilesProtectOptions
+    {
+        /// <summary>
+        /// Specifies the regex on the filename which if matched applies the associated FileProcessorFunction
+        /// </summary>
+        public Regex FilenameRegex { get; private set; }
+
+        /// <summary>
+        /// Specifies the FileProtectProcessor class implementing the <see cref="IFileProtectProcessor"/> interface used to read, encrypt and return the encrypted file as string.
+        /// </summary>
+        public IFileProtectProcessor FileProtectProcessor { get; private set; }
+
+
+        public FilesProtectOptions(Regex filenameRegex, IFileProtectProcessor protectFileProcessor)
+        {
+            FilenameRegex = filenameRegex;
+            FileProtectProcessor = protectFileProcessor;
+        }
+    }
+
+
+
+    /// <summary>
+    /// A raw file processor which parses and writes back input files as plain raw text files (no conventions are used).
+    /// </summary>
+    public class RawFileProtectProcessor : IFileProtectProcessor
+    {
+        /// <summary>
+        /// Please see <see cref="IFileProtectProcessor.ProtectFile"/> interface
+        /// </summary>
+        /// <param name="rawFileText">The is the raw input file as a string</param>
+        /// <param name="protectRegex">This is the configured protected regex which must be matched in file values in order to choose whether to encrypt or not the data.</param>
+        /// <param name="protectFunction">This is the protect function taking the plaintext data as input and producing encrypted base64 data as output</param>
+        /// <returns>the encrypted file as a string</returns>
+        public String ProtectFile(String rawFileText, Regex protectRegex, Func<String, String> ProtectFunction)
+        {
+            if (protectRegex.IsMatch(rawFileText))
+                rawFileText = ProtectFunction(rawFileText);
+
+            return rawFileText;
+        }
+    }
+
+
+
+    /// <summary>
+    /// A JSON file processor which parses and writes back input files according to the JSON file format, e.g. converts \\ into \, \u0022 into ", etc.
+    /// </summary>
+    public class JsonFileProtectProcessor : IFileProtectProcessor
+    {
+        /// <summary>
+        /// Please see <see cref="IFileProtectProcessor.ProtectFile"/> interface
+        /// </summary>
+        /// <param name="rawFileText">The is the raw input file as a string</param>
+        /// <param name="protectRegex">This is the configured protected regex which must be matched in file values in order to choose whether to encrypt or not the data.</param>
+        /// <param name="protectFunction">This is the protect function taking the plaintext data as input and producing encrypted base64 data as output</param>
+        /// <returns>the encrypted file as a string</returns>
+        public String ProtectFile(String rawFileText, Regex protectRegex, Func<String, String> protectFunction)
+        {
+            // Loads the JSON file
+            var document = JsonNode.Parse(rawFileText);
+
+            // extract and encrypts all string node values
+            // extraction must be done first because if you change any value while enumerating the collection it raises InvalidOperationException
+            foreach (var node in ExtractAllStringNodes(document, protectRegex, protectFunction))
+            {
+                String value = node.GetValue<String>();
+
+                // encrypts node value if it matches the regex
+                if (protectRegex.IsMatch(value))
+                {
+                    var parent = node.Parent;
+                    var parentType = parent.GetValueKind();
+
+                    // to change the actual value you have to differentiate if the parent node is a JSON object or a JSON array
+                    if (parentType == JsonValueKind.Object)
+                    {
+                        parent[node.GetPropertyName()] = protectFunction(value);
+                    }
+                    else if (parentType == JsonValueKind.Array)
+                    {
+                        parent[node.GetElementIndex()] = protectFunction(value);
+                    }
+                }
+            }
+
+            // returns back the encrypted json file
+            return document.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        }
+
+        
+
+        /// <summary>
+        /// Helper method which extracts all string nodes from the JSON document. It implements a recursive DFS of the JSON parsed tree.
+        /// </summary>
+        /// <param name="node">the actual node which must be visited, it starts with the root node</param>
+        /// <param name="protectRegex">This is the configured protected regex which must be matched in file values in order to choose whether to encrypt or not the data.</param>
+        /// <param name="protectFunction">This is the protect function taking the plaintext data as input and producing encrypted base64 data as output</param>
+        /// <returns>list of all string nodes</returns>
+        protected List<JsonNode> ExtractAllStringNodes(JsonNode node, Regex protectRegex, Func<String, String> protectFunction)
+        {
+            var result = new List<JsonNode>();
+
+            var nodeType = node.GetValueKind();
+
+            if (nodeType == JsonValueKind.Object)
+            {
+                foreach (var innerNodes in node.AsObject())
+                    if (innerNodes.Value != null)
+                        result.AddRange(ExtractAllStringNodes(innerNodes.Value, protectRegex, protectFunction));
+            }
+            else if (nodeType == JsonValueKind.Array)
+            {
+                foreach (var innerNodes in node.AsArray())
+                    if (innerNodes != null)
+                        result.AddRange(ExtractAllStringNodes(innerNodes, protectRegex, protectFunction));
+            }
+            else if (nodeType == JsonValueKind.String)
+            {
+                result.Add(node);
+            }
+
+            return result;
+        }
+    }
+
+
+
+    /// <summary>
+    /// A XML file processor which parses and writes back input files according to the XML file format, e.g. converts <![CDATA[&amp; into &, &gt; into >]]>, etc.
+    /// </summary>
+    public class XmlFileProtectProcessor : IFileProtectProcessor
+    {
+        /// <summary>
+        /// Please see <see cref="IFileProtectProcessor.ProtectFile"/> interface
+        /// </summary>
+        /// <param name="rawFileText">The is the raw input file as a string</param>
+        /// <param name="protectRegex">This is the configured protected regex which must be matched in file values in order to choose whether to encrypt or not the data.</param>
+        /// <param name="protectFunction">This is the protect function taking the plaintext data as input and producing encrypted base64 data as output</param>
+        /// <returns>the encrypted file as a string</returns>
+        public String ProtectFile(String rawFileText, Regex protectRegex, Func<String, String> protectFunction)
+        {
+            // Loads the XML File
+            var document = XDocument.Parse(rawFileText);
+
+            ProtectXmlNodes(document.Root, protectRegex, protectFunction);
+
+            // returns back the encrypted xml file
+            using (var xmlBytes = new MemoryStream())
+            {
+                document.Save(xmlBytes);
+                return Encoding.UTF8.GetString(xmlBytes.ToArray());
+            }
+        }
+
+
+
+        /// <summary>
+        /// Helper method which protects a node, all its attributes and its nested elements of the XML document. It implements a recursive DFS of the XML parsed tree.
+        /// </summary>
+        /// <param name="node">the actual node which must be visited, it starts with the root node</param>
+        /// <param name="protectRegex">This is the configured protected regex which must be matched in file values in order to choose whether to encrypt or not the data.</param>
+        /// <param name="protectFunction">This is the protect function taking the plaintext data as input and producing encrypted base64 data as output</param>
+        /// <returns>list of all string nodes</returns>
+        private static void ProtectXmlNodes(XElement element, Regex protectRegex, Func<string, string> protectFunction)
+        {
+            String value;
+
+            // protects all element attribute values
+            foreach (var attribute in element.Attributes())
+            {
+                value = attribute.Value;
+                if (protectRegex.IsMatch(value))
+                    attribute.Value = protectFunction(value);
+            }
+
+            if (element.HasElements)
+            {
+                // recursively protects nested elements
+                foreach (var nestedElement in element.Descendants())
+                    ProtectXmlNodes(nestedElement, protectRegex, protectFunction);
+
+            }
+            else
+            {
+                // protects element value if it has no children elements
+                value = element.Value;
+                if (protectRegex.IsMatch(value))
+                    element.Value = protectFunction(value);
+            }
+        }
+    }
+}

--- a/Fededim.Extensions.Configuration.Protected/ProtectedConfigurationData.cs
+++ b/Fededim.Extensions.Configuration.Protected/ProtectedConfigurationData.cs
@@ -23,7 +23,13 @@ namespace Fededim.Extensions.Configuration.Protected
         }
 
 
-        public ProtectedConfigurationData(String protectedRegexString = null, IServiceProvider dataProtectionServiceProvider = null, Action<IDataProtectionBuilder> dataProtectionConfigureAction = null, int keyNumber=1)
+        public ProtectedConfigurationData(String protectedRegexString = null, IServiceProvider dataProtectionServiceProvider = null, Action<IDataProtectionBuilder> dataProtectionConfigureAction = null, int keyNumber = 1) 
+            : this(protectedRegexString,dataProtectionServiceProvider,dataProtectionConfigureAction, ProtectedConfigurationBuilder.ProtectedConfigurationBuilderKeyNumberPurpose(keyNumber)) {
+
+        }
+
+
+        public ProtectedConfigurationData(String protectedRegexString = null, IServiceProvider dataProtectionServiceProvider = null, Action<IDataProtectionBuilder> dataProtectionConfigureAction = null, string purposeString = ProtectedConfigurationBuilder.ProtectedConfigurationBuilderPurpose)
         {
             // check that at least one parameter is not null
             if (String.IsNullOrEmpty(protectedRegexString) && dataProtectionServiceProvider == null && dataProtectionConfigureAction == null)
@@ -39,12 +45,12 @@ namespace Fededim.Extensions.Configuration.Protected
 
             // if dataProtectionServiceProvider is not null check that it resolves the IDataProtector
             if ((dataProtectionServiceProvider != null) &&
-                ((DataProtector = dataProtectionServiceProvider.GetRequiredService<IDataProtectionProvider>().CreateProtector(ProtectedConfigurationBuilder.DataProtectionPurpose(keyNumber))) == null))
+                ((DataProtector = dataProtectionServiceProvider.GetRequiredService<IDataProtectionProvider>().CreateProtector(purposeString)) == null))
                 throw new ArgumentException("Either dataProtectionServiceProvider or dataProtectionConfigureAction must configure the DataProtection services!", dataProtectionServiceProvider == null ? nameof(dataProtectionServiceProvider) : nameof(dataProtectionConfigureAction));
 
 
             // check that Regex contains a group named protectedData
-            ProtectedRegex = new Regex(protectedRegexString ?? ProtectedConfigurationBuilder.DefaultProtectedRegexString);
+            ProtectedRegex = new Regex(!String.IsNullOrEmpty(protectedRegexString) ? protectedRegexString : ProtectedConfigurationBuilder.DefaultProtectedRegexString);
             if (!ProtectedRegex.GetGroupNames().Contains("protectedData"))
                 throw new ArgumentException("Regex must contain a group named protectedData!", nameof(protectedRegexString));
         }

--- a/Fededim.Extensions.Configuration.Protected/ProtectedConfigurationProvider.cs
+++ b/Fededim.Extensions.Configuration.Protected/ProtectedConfigurationProvider.cs
@@ -87,7 +87,18 @@ namespace Fededim.Extensions.Configuration.Protected
                 if (Provider.TryGet(fullKey, out var value))
                 {
                     if (!String.IsNullOrEmpty(value))
-                        Provider.Set(fullKey, ProtectedConfigurationData.ProtectedRegex.Replace(value, me => ProtectedConfigurationData.DataProtector.Unprotect(me.Groups["protectedData"].Value)));
+                        Provider.Set(fullKey, ProtectedConfigurationData.ProtectedRegex.Replace(value, me =>
+                        {
+
+                            var subPurposePresent = !String.IsNullOrEmpty(me.Groups["subPurpose"]?.Value);
+
+                            var dataProtector = ProtectedConfigurationData.DataProtector;
+
+                            if (subPurposePresent)
+                                dataProtector = dataProtector.CreateProtector(me.Groups["subPurpose"].Value);
+
+                            return dataProtector.Unprotect(me.Groups["protectedData"].Value);
+                        }));
                 }
                 else DecryptChildKeys(fullKey);
             }

--- a/Fededim.Extensions.Configuration.ProtectedJson/Fededim.Extensions.Configuration.ProtectedJson.csproj
+++ b/Fededim.Extensions.Configuration.ProtectedJson/Fededim.Extensions.Configuration.ProtectedJson.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
      - Improvement: introduced FileProtectProcessor and IFileProtectProcessor interface for implementing a custom file protect processor used to read, encrypt and return the encrypted file as string. Json, Xml and Raw processors are provided by default.
      - Improvement: added custom string parameter purposeString in ProtectedConfigurationBuilder constructor in order to specify a custom purpose string for encryption/decryption, besides the integer keyNumber parameter.
      - Improvement: added subPurpose optional part in DefaultProtectRegexString, DefaultProtectedRegexString and DefaultProtectedReplaceString in order to allow an optional per key purpose string override.
      - Improvement: added some data to json (one element in Nullable:DoubleArray of appsettings.development.json) and xml file (AutoRetryDelaySubPurpose under TransientFaultHandlingOptions) of Fededim.Extensions.Configuration.Protected.ConsoleTest in order to exemplify the per key purpose string override.
